### PR TITLE
Add API Controllers for Topic Index and Show.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby "3.1.2"
 
 gem 'jquery-rails'
 
+gem "pundit"
+
 gem 'pg_search'
 
 gem "json"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,8 @@ GEM
     public_suffix (5.0.3)
     puma (5.6.6)
       nio4r (~> 2.0)
+    pundit (2.3.1)
+      activesupport (>= 3.0.0)
     racc (1.7.1)
     rack (2.2.8)
     rack-test (2.1.0)
@@ -312,6 +314,7 @@ DEPENDENCIES
   pg_search
   popper_js (~> 2.11.8)
   puma (~> 5.0)
+  pundit
   rails (~> 7.0.6)
   redis (~> 4.0)
   rest-client

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::BaseController < ActionController::API
+  include Pundit
+
+  after_action :verify_authorized, except: :index
+  after_action :verify_policy_scoped, only: :index
+
+  rescue_from Pundit::NotAuthorizedError,   with: :user_not_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
+  private
+
+  def user_not_authorized(exception)
+    render json: {
+      error: "Unauthorized #{exception.policy.class.to_s.underscore.camelize}.#{exception.query}"
+    }, status: :unauthorized
+  end
+
+  def not_found(exception)
+    render json: { error: exception.message }, status: :not_found
+  end
+end

--- a/app/controllers/api/v1/topics_controller.rb
+++ b/app/controllers/api/v1/topics_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::TopicsController < Api::V1::BaseController
+  before_action :set_topic, only: [ :show ]
+
+  def show
+  end
+
+  def index
+    @topics = policy_scope(Topic)
+  end
+
+  private
+
+  def set_topic
+    @topic = Topic.find(params[:id])
+    authorize @topic
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NotImplementedError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/topic_policy.rb
+++ b/app/policies/topic_policy.rb
@@ -1,0 +1,12 @@
+class TopicPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    def resolve
+      scope.all
+    end
+  end
+
+    def show?
+      true
+    end
+end

--- a/app/views/api/v1/topics/index.json.jbuilder
+++ b/app/views/api/v1/topics/index.json.jbuilder
@@ -1,0 +1,4 @@
+# app/views/api/v1/topics/index.json.jbuilder
+json.array! @topics do |topic|
+  json.extract! topic, :id, :name
+end

--- a/app/views/api/v1/topics/show.json.jbuilder
+++ b/app/views/api/v1/topics/show.json.jbuilder
@@ -1,0 +1,4 @@
+json.extract! @topic, :id, :name
+json.articles @topic.articles do |article|
+  json.extract! article, :title, :content, :url, :image_url
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,4 +33,9 @@ Rails.application.routes.draw do
   get "/profile", to: "pages#profile", as: :profile
   get "refresh_pins", to: "pages#refresh_pins"
 
+  namespace :api, defaults: { format: :json } do
+    namespace :v1 do
+      resources :topics, only: [ :index, :show ]
+    end
+  end
 end

--- a/test/policies/topic_policy_test.rb
+++ b/test/policies/topic_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class TopicPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
Currently can be accessed via api/v1/topics for Index. api/v1/topics/#topic_id for the show.

Example Topic Index JSON Output:
`[
    {
        "id": 1,
        "name": "business"
    },
    {
        "id": 2,
        "name": "entertainment"
    },
    {
        "id": 3,
        "name": "environment"
    },
    {
        "id": 4,
        "name": "food"
    },
    {
        "id": 5,
        "name": "health"
    },
    {
        "id": 6,
        "name": "politics"
    },
    {
        "id": 7,
        "name": "science"
    },
    {
        "id": 8,
        "name": "sports"
    },
    {
        "id": 9,
        "name": "technology"
    },
    {
        "id": 10,
        "name": "top"
    },
    {
        "id": 11,
        "name": "tourism"
    },
    {
        "id": 12,
        "name": "world"
    },
    {
        "id": 13,
        "name": "Everton transfer update"
    },
    {
        "id": 14,
        "name": "Toffees winger's future"
    },
    {
        "id": 15,
        "name": "Potential sale of star player"
    },
    {
        "id": 16,
        "name": "Contract negotiations"
    },
    {
        "id": 17,
        "name": "Wide options for Everton"
    },
    {
        "id": 18,
        "name": "Gin Bothy's move to Forfar"
    },
    {
        "id": 19,
        "name": "Expansion of production capabilities"
    },
    {
        "id": 20,
        "name": "Bringing brands under one roof"
    },
    {
        "id": 21,
        "name": "Importance of keeping production in Angus"
    },
    {
        "id": 22,
        "name": "Growth of the Scottish gin industry"
    },
    {
        "id": 23,
        "name": "biden"
    },
    {
        "id": 24,
        "name": "trump"
    },
    {
        "id": 25,
        "name": "pizza"
    },
    {
        "id": 26,
        "name": "cat"
    }
]`

Example: Topic Show JSON Output:
`{
    "id": 6,
    "name": "politics",
    "articles": [
        {
            "title": "The criminalization of politics to get Trump is endangering everyone's rights",
            "content": "The U.S. Constitution is clear: Political speech is protected by the First Amendment.\n\n Also, battles over the acceptance of electors to validate a presidential election are wholly within the political realm and should not be subject to criminal sanctions. Yet our nation is very close to setting a dangerous precedent by criminalizing speech and politics, and one political faction is rushing into this folly headlong. If the Biden administration is allowed to criminalize speech and politics, we will become a nation where the losers of presidential elections are arrested instead of being sent into retirement with book tours and libraries.\n\n The criminalization of politics is a dangerous game that Democrats used to decry, when they thought the shoe . No matter how you feel about former President Donald Trump’s activities after the 2020 election, the reaction of putting Trump in jail for his speech and activities to organize opposition to Congress counting Electoral College votes would degrade our political system and set the precedent that one party can criminalize the political activities of the other. Notwithstanding all the legal spin you are hearing on a day-to-day basis from talking heads on cable television, it is a fact that the First Amendment to the Constitution vindicates the freedom of political speech.\n\n When you hear the talking point that “you can’t yell fire in a crowded theater,” know that the media are trying to gaslight you — to make you believe that there are limits to political free speech, when in fact there aren’t. If government is permitted to redefine the Bill of Rights as something subjective and not containing inalienable rights, then the government can take anyone’s rights away, including yours. Yelling fire in a crowded theater has nothing to do with political speech.\n\n It is also a red herring in the discussion of free speech. The position that this is an exception to the First Amendment was by the justice who first coined the phrase, and . Yet the left today is using the fire-in-a-theater example as a pretext for criminalizing some political speech, and to make believe that your natural right to express unpopular political beliefs has limits.\n\n It does not. No, you can’t incite a riot. No, you can’t threaten to kill somebody.\n\n And you can’t libel another person, either. But these things are not what the First Amendment to the Constitution recognizes as an absolute right. Freedom of speech, like our other rights, do not derive from government.\n\n They are natural, some would say God-given. They pre-date the Constitution. The right not to be jailed for expressing political opinions is a natural right that government cannot take away, recognized but not given to us by the Constitution.\n\n Regarding Trump’s so called “fake electors” scheme and the attempt to manipulate the counting of Electoral College votes in 2021, that was a political exercise that is protected by the Constitution. I don’t agree with efforts to reject election certificates by Congress, nor do I believe Trump’s contention that the vice president ever had the power to do such a thing. Yet I also recognize that this effort to game the system was a clear case of political and legal maneuvering, not of criminal conspiracy.\n\n If you want to imprison Trump for attempting to disenfranchise voters on these grounds, then you might want to look at Trump critic (D-Md.) antics, when he tried to disenfranchise all the Floridians who voted in the 2016 election. Or what about after the 2004 re-election of President George W.\n\n Bush, when , based entirely on bogus conspiracy theories about voting machines? Should Raskin and all those Democratic House members who tried to disenfranchise voters be prosecuted for their attempt to negate the sacred voting rights of American citizens? Their actions were morally wrong and violated their sacred oaths, yet I believe it would be wrong to hold them criminally liable for such engagement in partisan politics. With regard to the cases against Trump in Georgia and Washington, the courts should simply dismiss the charges. Our constitutional system relies on the good faith of politicians, which is lacking today, to uphold their oaths and take ethical actions that respect the unalienable rights of the people to engage in political speech and politics.\n\n The freedom of political speech is absolute. The idea that politicians can work to seat different slates of electors, or that they can speak or vote against seating electors, is wholly within the realm of politics. Most agree that disenfranchising voters is wrong, yet the system held against such chicanery on Jan.\n\n 6. Biden’s victory was duly recorded. Attempts by Republicans and Democrats to disenfranchise voters over the years have repeatedly failed.\n\n This use of Trump to set a new standard that criminalizes engagement in politics and free speech will endanger every voter’s rights. Let’s hope this effort to criminalize politics fails",
            "url": "https://thehill.com/opinion/criminal-justice/4171606-the-criminalization-of-politics-to-get-trump-is-endangering-everyones-rights/",
            "image_url": "https://thehill.com/wp-content/uploads/sites/2/2023/08/MugshotsFultonCounty.jpg?w=900"
        }
    ]
}`
